### PR TITLE
relax requirements on Key type

### DIFF
--- a/include/interval_tree.h
+++ b/include/interval_tree.h
@@ -2,6 +2,7 @@
 #define INTERVAL_TREE_H
 
 #include <algorithm>
+#include <type_traits>
 #include <vector>
 #include <utility>
 #include <stdexcept>
@@ -10,7 +11,7 @@ template<
     typename Key,
     typename T,
     typename Compare = std::less<Key>,
-    typename std::enable_if<std::is_arithmetic<Key>::value, int>::type = 0
+    typename std::enable_if<std::is_default_constructible<Key>::value, int>::type = 0
 >
 class interval_tree
 {
@@ -50,7 +51,7 @@ public:
 
         int         height  = 1;
         int         bfactor = 0;
-        bound_type  max     = 0;
+        bound_type  max = bound_type();
         value_type  data;
     };
 
@@ -722,21 +723,21 @@ private:
 
         if(n->right)
         {
-            m = std::max(m, n->right->max);
+            m = std::max(m, n->right->max, comp.comp);
             h = n->right->height + 1;
             b = n->right->height;
         }
 
         if(n->left)
         {
-            m  = std::max(m, n->left->max);
+            m  = std::max(m, n->left->max, comp.comp);
             h  = std::max(h, n->left->height + 1);
             b -= n->left->height;
         }
 
 
 
-        if(n->max     != m ||
+        if(comp.neq(n->max, m) ||
            n->height  != h ||
            n->bfactor != b ||
            (!n->left && !n->right))


### PR DESCRIPTION
As discussed in #1, here's my attempt at allowing custom types to be used as bounds.

**What I did**
- Change the default value of `node.max` from `0` to `bound_type()`
  Otherwise compilers will complain if a `Key` cannot be constructed from an `int`.
  :warning: Is using `bound_type()` as the value for a default member initializer even ok ? It seems to work but it looks unusual to me.
- Change the requirement on `Key` to `std::is_default_constructible<Key>`
  This is because of the previous change, I want to make sure we can call `bound_type()`
- Explicitly pass the `Compare` instance to `std::max()` in `update_props`
  This was the simplest way I could think of that would compile and pass tests while allowing custom comparison
- Use `comp.neq()` instead of `!=` in `update_props()`
  It's a very roundabout way of using `!=` for simpler types ... but it works
- Add some minimal tests to show that you can use a custom `Key` type with either :
  - a defined `operator<()`, which gets picked up by `std::less<Key>` and removes the need to explicitly pass a comparison function
  - a completely separate comparison function, that you have to pass explicitly when constructing the `interval_tree`