### PR TITLE
Fix infinite loop in operator==

### DIFF
--- a/include/interval_tree.h
+++ b/include/interval_tree.h
@@ -1206,7 +1206,7 @@ bool operator==(const interval_tree<K, T, C>& lhs,
     auto rit = rhs.cbegin();
     auto er  = rhs.cend();
 
-    while(lit != el && rit != er)
+    for(;lit != el && rit != er; ++lit, ++rit)
     {
         if(*lit != *rit)
             return false;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -619,6 +619,42 @@ TEST_CASE("Find interval", "[test]")
     }
 }
 
+TEST_CASE("Equality", "[test]")
+{
+    itree tree{
+        {{0, 1}, "value0"},
+        {{1, 2}, "value1"},
+    };
+
+    itree tree2;
+    tree2.insert({{1, 2}, "value1"});
+    tree2.insert({{0, 1}, "value0"});
+
+    REQUIRE(tree == tree2);
+
+    itree tree3{
+        {{0, 1}, "value0"},
+        {{1, 2}, "value1"},
+        {{1, 2}, "value1"},
+    };
+
+    REQUIRE(tree != tree3);
+
+    itree tree4{
+        {{0, 1}, "value0"},
+        {{1, 3}, "value1"},
+    };
+
+    REQUIRE(tree != tree4);
+
+    itree tree5{
+        {{0, 1}, "value0"},
+        {{1, 2}, "value2"},
+    };
+
+    REQUIRE(tree != tree5);
+}
+
 struct naive_fraction {
     int numerator = 0;
     int denominator = 1;


### PR DESCRIPTION
Long story short, I recently started writing unit tests for my own code (which uses `interval_tree` under the hood) and one of my tests was never able to finish. As it turns out, in `operator==` between two interval trees,  the iterators used to compare each element are never incremented, resulting in an infinite loop.

Long live unit tests !