### PR TITLE
Fix reverse iterators

### DIFF
--- a/include/interval_tree.h
+++ b/include/interval_tree.h
@@ -145,7 +145,7 @@ public:
             if(n)
                 n = tree->next(n);
             else
-                n = tree->leftest(n);
+                n = tree->root ? tree->leftest(tree->root) : nullptr;
 
             return *this;
         }
@@ -162,7 +162,7 @@ public:
             if(n)
                 n = tree->prev(n);
             else
-                n = tree->rightest(n);
+                n = tree->root ? tree->rightest(tree->root) : nullptr;
 
             return *this;
         }
@@ -219,7 +219,7 @@ public:
             if(n)
                 n = tree->next(n);
             else
-                n = tree->leftest(n);
+                n = tree->root ? tree->leftest(tree->root) : nullptr;
 
             return *this;
         }
@@ -236,7 +236,7 @@ public:
             if(n)
                 n = tree->prev(n);
             else
-                n = tree->rightest(n);
+                n = tree->root ? tree->rightest(tree->root) : nullptr;
 
             return *this;
         }
@@ -353,32 +353,32 @@ public:
 
     inline reverse_iterator rbegin() noexcept
     {
-        return reverse_iterator(begin());
+        return reverse_iterator(end());
     }
 
     inline reverse_const_iterator rbegin() const noexcept
     {
-        return reverse_const_iterator(begin());
+        return reverse_const_iterator(end());
     }
 
     inline reverse_const_iterator crbegin() const noexcept
     {
-        return reverse_const_iterator(cbegin());
+        return reverse_const_iterator(cend());
     }
 
     inline reverse_iterator rend() noexcept
     {
-        return reverse_iterator(end());
+        return reverse_iterator(begin());
     }
 
     inline reverse_const_iterator rend() const noexcept
     {
-        return reverse_const_iterator(end());
+        return reverse_const_iterator(begin());
     }
 
     inline reverse_const_iterator crend() const noexcept
     {
-        return reverse_const_iterator(cend());
+        return reverse_const_iterator(cbegin());
     }
 
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -458,12 +458,14 @@ TEST_CASE("Ordering", "[test]")
     SECTION("reverse Base")
     {
         auto comp = tree.value_comp();
-
+        bool actually_checked = false;
         REQUIRE(std::is_sorted(tree.rbegin(), tree.rend(),
         [&](const value_type& a, const value_type& b)
         {
+            actually_checked = true;
             return !comp(a, b);
         }));
+        REQUIRE(actually_checked);
     }
 
     SECTION("reverse With insert")
@@ -781,6 +783,29 @@ TEST_CASE("Custom Comparator", "[test]")
         actual_values.clear();
         tree4.in({0, 1}, {1, 5}, [&](auto it){return actual_values.insert(it->second);});
         REQUIRE(expected_values == actual_values);
+    }
+}
+
+TEST_CASE("Iterators", "[test]")
+{
+    itree tree{
+        {{0, 1}, "value0"},
+        {{1, 2}, "value1"},
+        {{2, 3}, "value2"},
+        {{3, 4}, "value3"},
+        {{4, 5}, "value4"},
+        {{5, 6}, "value5"},
+        {{6, 7}, "value6"}
+    };
+
+    SECTION("Reverse")
+    {
+        REQUIRE(tree.rbegin()->second == "value6");
+    }
+
+    SECTION("Const Reverse")
+    {
+        REQUIRE(tree.crbegin()->second == "value6");
     }
 }
 


### PR DESCRIPTION
I think reverse iterators were broken, so I fixed them :

I was surprised my own code was hitting a reproducible segfault when trying to deref the output of `.crbegin()`, same problem with `.rbegin()`, which looked suspicious to me.

I was able to reproduce the segfault in a simple unit test so I started debugging.

So after much head-scratching I think I finally understand what was broken, and why the unit tests that already existed and used `.rbegin()` were "working" :

**1. `(c)rbegin` and `(c)rend` were constructing the iterators the wrong way around**

I usually hate having to read cppreference carefully, but for once [the usage example of std::reverse_iterator](https://en.cppreference.com/w/cpp/iterator/reverse_iterator#Example) wasn't *that* complicated (Although I think they could have made it simpler still). From what I understood, to implement `rbegin()` with `std::reverse_iterator` you need to give it `end()`, not `begin()`. This was done the other way around in the original code. This *should* have resulted in a failure somewhere in unit tests, but :

**2. `iterator::operator++()` and `iterator::operator--()` were behaving unexpectedly**

In the original code, operator++ does this : 
```cpp
if(n)
    n = tree->next(n);
else
    n = tree->leftest(n);
```
Being in the else branch means `n` is `nullptr` (I think ?).

From what I understood, `nullptr` is used as the sentinel when iterating forward.

So `n` being `nullptr` means the iterator (conceptually) points "past the end" of the tree.

Where should we point to when going past-past the end ? Since the original code calls `leftest`, I guess the intent was to wrap around and point back to the leftmost node. The code of `leftest` does not check if it has been given a `nullptr` so I think calling it with `n` in this context does not do what was inteded. I fixed it by replacing the line with :

```cpp
n = tree->root ? tree->leftest(tree->root) : nullptr;
```

Another possibility would have been to do nothing in that case, let me know if I should change the code so it does that instead.

The situation in `operator--` is slightly different : when we are past-the-end of the tree (`n` is `nullptr`) and we go backwards, I think the only sensible thing to do is point back at the last element of the tree, no other reasonable option in my opinion. The fix is similar to that of `operator++`

**Bonus : Why the unit tests which used `.rbegin()` "worked"**

There are several places where the unit tests do this :

```cpp
REQUIRE(std::is_sorted(tree.rbegin(), tree.rend(),
[&](const value_type& a, const value_type& b)
{
    return !comp(a, b);
}));
```

The trick was that, in the original code, the lambda was never actually called, since calling it would mean de-referencing a reverse iterator, which would segfault

In the original code, `.rbegin()` returns `std::reverse_iterator(begin())`. the funny bit is what happens next in `std::is_sorted`, if we look at a typical implementation (of is_sorted_until which is basically the same thing) : 
```cpp
template <class ForwardIt, class Compare>
ForwardIt is_sorted_until(ForwardIt first, ForwardIt last, Compare comp) 
{
    if (first != last) {
        ForwardIt next = first;
        while (++next != last) {
            if (comp(*next, *first))
                return next;
            first = next;
        }
    }
    return last;
}
```

We see the two iterators are compared with `!=` in the if, since they are both **reverse** iterator, this check uses `.base()` under the hood so no out-of-bounds deref there : `first.base()` is just `.begin()` and `last.base()` is `.end()`, they compare unequal, the function continues

But right after that, `next` is pre-*incremented* in the condition of the while loop.

Since `next` is a **reverse** iterator, this actually calls `operator--()` and not `operator++()` on our original iterator :
```cpp
inline iterator& operator--()
{
    if(n)
        n = tree->prev(n);
    else
        n = tree->rightest(n);

    return *this;
}
```
n is just `begin()` at this point, so we call `tree->prev(n)`, with `n` pointing to the leftmost node in the tree :
```cpp
inline node* prev(node* n) const
{
    if(n->left)
        return rightest(n->left);

    while(n->parent && is_left_child(n))
        n = n->parent;

    return n->parent;
}
```
`n` is the leftmost node, so it has no left child, we skip the if statement, and go straight to the while loop.

Since `n` is the leftmost node, all its ancestors are left children as well, so the while loop takes us back to the root, then we return `root->parent` which is `nullptr`

Going back up to inside `std::is_sorted`, this means that, right after per-incrementation, `next` is now the end iterator, since the underlying node pointer is `nullptr`, so we exit the function, never having called `comp`

:tada: Tada !