### PR TITLE
Fix move assignement and move constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(./third_party/Catch2)
 
 enable_testing()
 
+add_compile_definitions(INTERVAL_TREE_UNIT_TESTING)
 add_executable(${PROJECT_NAME} test/main.cpp)
 target_link_libraries(${PROJECT_NAME} Catch2::Catch2)
 

--- a/include/interval_tree.h
+++ b/include/interval_tree.h
@@ -269,7 +269,7 @@ public:
     }
 
     interval_tree(const interval_tree<Key, T>& copy) { *this = copy; }
-    interval_tree(interval_tree<Key, T>&& move) { *this = move; }
+    interval_tree(interval_tree<Key, T>&& move) { *this = std::move(move); }
     interval_tree(std::initializer_list<value_type> ilist, const Compare& comp = Compare()) :
         comp(comp)
     {
@@ -306,6 +306,11 @@ public:
         root = std::move(move.root);
         node_count = std::move(move.node_count);
         comp = std::move(move.comp);
+
+        // Don't actually destroy move's content (since it's currently still
+        // refering to the same stuff as *this), just make sure the call to the
+        // destructor on move won't delete the contents of *this
+        move.root = nullptr;
 
         return *this;
     }
@@ -1172,6 +1177,13 @@ private:
     {
         return {_lower_bound<IT>(k), _upper_bound<IT>(k)};
     }
+
+#ifdef INTERVAL_TREE_UNIT_TESTING
+public:
+    node* __get_root() {
+        return root;
+    }
+#endif
 
 private:
     node*      root = nullptr;


### PR DESCRIPTION
I'm still testing my own code, and found something else.

The move constructor was actually calling the copy constructor (maybe that was intentional ?) and the move assignment op was not "releasing" the pointer to the tree root on the source object so when the source object would be destroyed it would delete its root, which would still point to the same node as that of the destination object, so the next time you would try to do anything with the destination object your program would segfault pretty quickly.